### PR TITLE
Synchronise devDeps and peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "showdown": "^1.9.1"
   },
   "peerDependencies": {
-    "ra-core": "^2.9.9"
+    "ra-core": "^3.18.0"
   },
   "babel": {
     "ignore": [


### PR DESCRIPTION
Without this change getting an error with npm@7:
```sh
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: backend@1.0.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"17.0.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.3.0" from ra-core@2.9.9
npm ERR! node_modules/ra-core
npm ERR!   peer ra-core@"^2.9.9" from ra-input-markdown@1.3.0
npm ERR!   node_modules/ra-input-markdown
npm ERR!     ra-input-markdown@"1.3.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```